### PR TITLE
Here is the rewritten commit message:

### DIFF
--- a/app/components/games/orbital-flux/components/GameCanvas.tsx
+++ b/app/components/games/orbital-flux/components/GameCanvas.tsx
@@ -22,8 +22,8 @@ export function GameCanvas({ gameState, config, className }: GameCanvasProps) {
 		if (!container) return { width: 600, height: 600, scale: 1 };
 
 		const containerRect = container.getBoundingClientRect();
-		const availableWidth = containerRect.width - 32; // padding
-		const availableHeight = containerRect.height - 32; // padding
+		const availableWidth = containerRect.width - 0; // No internal horizontal padding
+		const availableHeight = containerRect.height - 0; // No internal vertical padding
 
 		const { gridWidth, gridHeight } = config;
 		const aspectRatio = gridWidth / gridHeight;

--- a/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
+++ b/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
@@ -4,13 +4,28 @@ import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { TimeAgo } from '~/components/TimeAgo';
 
-export function LivePerksPanel({ gameId }: { gameId: Id<'games'> }) {
+interface LiveInfoPanelProps {
+    gameId: Id<'games'>;
+    elapsedTime: string;
+}
+
+export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) {
 	//
 	const query = convexQuery(api.payments.public.all, { gameId });
 	const { data: payments } = useSuspenseQuery(query);
 
 	return (
-		<div className="w-80 bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-lg">
+		<div className="h-full flex flex-col bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-lg">
+			{/* Game ID and Elapsed Time Section */}
+			<div className="p-4 border-b border-border">
+				<h2 className="text-lg font-semibold text-center text-foreground">Live Game Info</h2>
+				<div className="mt-2 space-y-1 text-sm font-mono text-muted-foreground">
+					<p>Game ID: {gameId}</p>
+					<p>Elapsed Time: {elapsedTime}</p>
+				</div>
+			</div>
+
+			{/* Perks Call to Action (based.market/perks) */}
 			<div className="p-4 border-b border-border">
 				<div className="text-center">
 					<p className="text-lg font-semibold text-card-foreground">
@@ -21,7 +36,8 @@ export function LivePerksPanel({ gameId }: { gameId: Id<'games'> }) {
 				</div>
 			</div>
 
-			<div className="p-4 space-y-2">
+			{/* Perks List */}
+			<div className="p-4 space-y-2 overflow-y-auto flex-1">
 				{payments.length < 1 ? (
 					<div className="text-center text-muted-foreground text-sm">No perks purchased yet</div>
 				) : (

--- a/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
+++ b/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
@@ -3,25 +3,46 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { TimeAgo } from '~/components/TimeAgo';
+import type { GameConfig } from '~/components/games/orbital-flux/types'; // Add import
 
 interface LiveInfoPanelProps {
     gameId: Id<'games'>;
     elapsedTime: string;
+    config: GameConfig; // Add config prop
 }
 
-export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) {
+export function LiveInfoPanel({ gameId, elapsedTime, config }: LiveInfoPanelProps) {
 	//
 	const query = convexQuery(api.payments.public.all, { gameId });
 	const { data: payments } = useSuspenseQuery(query);
 
 	return (
 		<div className="h-full flex flex-col bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-lg">
-			{/* Game ID and Elapsed Time Section */}
-			<div className="p-4 border-b border-border">
-				<h2 className="text-lg font-semibold text-center text-foreground">Live Game Info</h2>
-				<div className="mt-2 space-y-1 text-sm font-mono text-muted-foreground">
-					<p>Game ID: {gameId}</p>
-					<p>Elapsed Time: {elapsedTime}</p>
+			{/* New Section for Game Info (ID, Time, Config) */}
+			<div className="p-3 border-b border-border space-y-1 text-xs"> {/* Reduced space-y-2 to space-y-1 */}
+				{/* Row 1: Elapsed Time */}
+				<div className="flex items-center justify-between">
+					<span className="text-muted-foreground">Elapsed:</span>
+					<span className="font-mono text-foreground">{elapsedTime}</span>
+				</div>
+
+				{/* Row 2: Game ID (no label) & Grid Size */}
+				<div className="flex items-center justify-between">
+					<span className="font-mono text-foreground truncate" title={gameId.toString()}>{gameId.toString().substring(gameId.toString().length - 8)}</span> {/* Show last 8 chars of ID, full ID on hover */}
+					<div className="flex items-center space-x-1">
+						{/* Consider adding a small grid icon here later if possible */}
+						<span className="text-muted-foreground">Grid:</span>
+						<span className="font-mono text-foreground">{config.gridWidth}x{config.gridHeight}</span>
+					</div>
+				</div>
+
+				{/* Row 3: Orb Speed (potentially other compact info here too) */}
+				<div className="flex items-center justify-end"> {/* Align to right if it's a single item */}
+					<div className="flex items-center space-x-1">
+						{/* Consider adding a small speed icon here later */}
+						<span className="text-muted-foreground">Speed:</span>
+						<span className="font-mono text-foreground">{config.orbSpeed}</span>
+					</div>
 				</div>
 			</div>
 

--- a/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
+++ b/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
@@ -1,19 +1,18 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { convexQuery } from '@convex-dev/react-query';
-import { useSuspenseQuery } from '@tanstack/react-query';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { TimeAgo } from '~/components/TimeAgo';
 // import type { GameConfig } from '~/components/games/orbital-flux/types'; // GameConfig not needed
 
 interface LiveInfoPanelProps {
-    gameId: Id<'games'>;
-    elapsedTime: string; // elapsedTime is not used anymore but kept for now as per instructions
-    // config: GameConfig; // config prop removed
+	gameId: Id<'games'>;
+	elapsedTime: string; // elapsedTime is not used anymore but kept for now as per instructions
+	// config: GameConfig; // config prop removed
 }
 
-export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) { // config removed from destructuring
+export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) {
+	// config removed from destructuring
 	//
 	const query = convexQuery(api.payments.public.all, { gameId });
 	const { data: payments } = useSuspenseQuery(query);
@@ -26,9 +25,7 @@ export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) { // 
 			<div className="p-4 border-b border-border">
 				<div className="text-center">
 					<p className="text-lg font-semibold text-card-foreground">
-						<span className="text-blue-500 underline">based.market/perks</span>
-						<br />
-						to support a team!
+						Visit <span className="text-blue-500 underline">based.market/perks</span> to support a team!
 					</p>
 				</div>
 			</div>
@@ -36,7 +33,9 @@ export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) { // 
 			{/* Perks List */}
 			<div className="p-4 space-y-2 overflow-y-auto flex-1">
 				{payments.length < 1 ? (
-					<div className="text-center text-muted-foreground text-sm">No perks purchased yet</div>
+					<div className="text-center text-muted-foreground text-sm h-full w-full flex items-center justify-center">
+						No perks used yet
+					</div>
 				) : (
 					payments.map((payment) => <PerkItem key={payment._id} payment={payment} />)
 				)}
@@ -51,9 +50,7 @@ export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) { // 
 					</span>
 
 					{/* Elapsed Time */}
-					<span className="font-mono">
-						{elapsedTime}
-					</span>
+					<span className="font-mono">{elapsedTime}</span>
 				</div>
 			</div>
 		</div>

--- a/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
+++ b/app/components/games/orbital-flux/components/LiveInfoPanel.tsx
@@ -1,52 +1,28 @@
 import { convexQuery } from '@convex-dev/react-query';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { convexQuery } from '@convex-dev/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { api } from 'convex/_generated/api';
 import { Id } from 'convex/_generated/dataModel';
 import { TimeAgo } from '~/components/TimeAgo';
-import type { GameConfig } from '~/components/games/orbital-flux/types'; // Add import
+// import type { GameConfig } from '~/components/games/orbital-flux/types'; // GameConfig not needed
 
 interface LiveInfoPanelProps {
     gameId: Id<'games'>;
-    elapsedTime: string;
-    config: GameConfig; // Add config prop
+    elapsedTime: string; // elapsedTime is not used anymore but kept for now as per instructions
+    // config: GameConfig; // config prop removed
 }
 
-export function LiveInfoPanel({ gameId, elapsedTime, config }: LiveInfoPanelProps) {
+export function LiveInfoPanel({ gameId, elapsedTime }: LiveInfoPanelProps) { // config removed from destructuring
 	//
 	const query = convexQuery(api.payments.public.all, { gameId });
 	const { data: payments } = useSuspenseQuery(query);
 
 	return (
 		<div className="h-full flex flex-col bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-lg">
-			{/* New Section for Game Info (ID, Time, Config) */}
-			<div className="p-3 border-b border-border space-y-1 text-xs"> {/* Reduced space-y-2 to space-y-1 */}
-				{/* Row 1: Elapsed Time */}
-				<div className="flex items-center justify-between">
-					<span className="text-muted-foreground">Elapsed:</span>
-					<span className="font-mono text-foreground">{elapsedTime}</span>
-				</div>
+			{/* Info Section Removed */}
 
-				{/* Row 2: Game ID (no label) & Grid Size */}
-				<div className="flex items-center justify-between">
-					<span className="font-mono text-foreground truncate" title={gameId.toString()}>{gameId.toString().substring(gameId.toString().length - 8)}</span> {/* Show last 8 chars of ID, full ID on hover */}
-					<div className="flex items-center space-x-1">
-						{/* Consider adding a small grid icon here later if possible */}
-						<span className="text-muted-foreground">Grid:</span>
-						<span className="font-mono text-foreground">{config.gridWidth}x{config.gridHeight}</span>
-					</div>
-				</div>
-
-				{/* Row 3: Orb Speed (potentially other compact info here too) */}
-				<div className="flex items-center justify-end"> {/* Align to right if it's a single item */}
-					<div className="flex items-center space-x-1">
-						{/* Consider adding a small speed icon here later */}
-						<span className="text-muted-foreground">Speed:</span>
-						<span className="font-mono text-foreground">{config.orbSpeed}</span>
-					</div>
-				</div>
-			</div>
-
-			{/* Perks Call to Action (based.market/perks) */}
+			{/* Perks Call to Action (based.market/perks) - this will now be the first child */}
 			<div className="p-4 border-b border-border">
 				<div className="text-center">
 					<p className="text-lg font-semibold text-card-foreground">
@@ -64,6 +40,21 @@ export function LiveInfoPanel({ gameId, elapsedTime, config }: LiveInfoPanelProp
 				) : (
 					payments.map((payment) => <PerkItem key={payment._id} payment={payment} />)
 				)}
+			</div>
+
+			{/* New Footer Section */}
+			<div className="p-2 border-t border-border text-xs text-muted-foreground">
+				<div className="flex items-center justify-between gap-3">
+					{/* Game ID (Full) */}
+					<span className="font-mono truncate" title={gameId.toString()}>
+						{gameId}
+					</span>
+
+					{/* Elapsed Time */}
+					<span className="font-mono">
+						{elapsedTime}
+					</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/routes/games/orbital-flux_.live.tsx
+++ b/app/routes/games/orbital-flux_.live.tsx
@@ -8,7 +8,8 @@ import { Loading } from '~/components/Loading';
 import OrbitalFlux from '~/components/games/orbital-flux/OrbitalFlux';
 import { ConfigPanel } from '~/components/games/orbital-flux/components/ConfigPanel';
 import { LiveCountdownBar } from '~/components/games/orbital-flux/components/LiveCountdownBar';
-import { LivePerksPanel } from '~/components/games/orbital-flux/components/LivePerksPanel';
+// import { LivePerksPanel } from '~/components/games/orbital-flux/components/LivePerksPanel'; // No longer used directly
+import { LiveInfoPanel } from '~/components/games/orbital-flux/components/LiveInfoPanel'; // Add import
 import { DEFAULT_GAME_CONFIG, LIVE_COUNTDOWN_DURATION } from '~/components/games/orbital-flux/constants';
 import type { GameConfig } from '~/components/games/orbital-flux/types';
 import { Button } from '~/components/ui/button';
@@ -363,16 +364,16 @@ function RouteComponent() {
 		const elapsedTime = formatElapsedTime(gameStartTime, currentTime);
 
 		return (
-			<div className="h-screen bg-background flex flex-col overflow-hidden">
-				{/* game area */}
-				<div className="flex-1">
+			<div className="h-screen bg-background flex flex-row overflow-hidden">
+				{/* Left Section (Game Area) */}
+				<div className="flex-shrink-0 flex justify-center items-center p-4 relative w-auto">
 					<OrbitalFlux
 						gameId={currentGameId}
 						enablePerks={true}
 						showStats={true}
 						autoStart={true}
 						customStatsBar={customStatsBar}
-						customRightPanel={<LivePerksPanel gameId={currentGameId} />}
+						// customRightPanel is removed
 						showSidebarToggle={false}
 						hideGameControls={true}
 						onWinner={handleWinner}
@@ -382,11 +383,9 @@ function RouteComponent() {
 					/>
 				</div>
 
-				{/* game ID and elapsed time footer */}
-				<div className="bg-background/80 backdrop-blur-sm border-t border-border">
-					<p className="text-xs text-muted-foreground text-center font-mono py-2">
-						{currentGameId} • Elapsed: {elapsedTime}
-					</p>
+				{/* Right Section (Info Panel) */}
+				<div className="flex-1 bg-card border-l border-border p-4 overflow-y-auto">
+					<LiveInfoPanel gameId={currentGameId} elapsedTime={elapsedTime} />
 				</div>
 			</div>
 		);

--- a/app/routes/games/orbital-flux_.live.tsx
+++ b/app/routes/games/orbital-flux_.live.tsx
@@ -17,17 +17,36 @@ import { Button } from '~/components/ui/button';
 // NOTE: Add LIVE_GAME_PASSWORD to your .env.local file for live game control
 
 /**
- * formats elapsed time from milliseconds to MM:SS format
+ * formats elapsed time from milliseconds to DD:HH:MM:SS, HH:MM:SS or MM:SS format
  */
 function formatElapsedTime(startTime: number | undefined, currentTime: number): string {
-	//
 	if (!startTime) return '00:00';
 
-	const elapsed = Math.max(0, currentTime - startTime);
-	const minutes = Math.floor(elapsed / 60000);
-	const seconds = Math.floor((elapsed % 60000) / 1000);
+	let elapsed = Math.max(0, currentTime - startTime) / 1000; // work in seconds
 
-	return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+	const days = Math.floor(elapsed / (24 * 60 * 60));
+	elapsed %= (24 * 60 * 60);
+
+	const hours = Math.floor(elapsed / (60 * 60));
+	elapsed %= (60 * 60);
+
+	const minutes = Math.floor(elapsed / 60);
+	const seconds = Math.floor(elapsed % 60);
+
+	let parts: string[] = [];
+	if (days > 0) {
+		parts.push(days.toString().padStart(2, '0'));
+		parts.push(hours.toString().padStart(2, '0'));
+	} else if (hours > 0) {
+		parts.push(hours.toString().padStart(2, '0'));
+	}
+	parts.push(minutes.toString().padStart(2, '0'));
+	parts.push(seconds.toString().padStart(2, '0'));
+
+	// This logic simplifies: if days > 0, parts is [DD, HH, MM, SS]
+	// if hours > 0 (and days = 0), parts is [HH, MM, SS]
+	// otherwise, parts is [MM, SS] (or [00, SS] if minutes < 1)
+	return parts.join(':');
 }
 
 /**
@@ -366,7 +385,7 @@ function RouteComponent() {
 		return (
 			<div className="h-screen bg-background flex flex-row overflow-hidden">
 				{/* Left Section (Game Area) */}
-				<div className="flex-shrink-0 flex justify-center items-center p-4 relative w-auto">
+				<div className="flex-shrink-0 flex justify-center items-center relative w-auto">
 					<OrbitalFlux
 						gameId={currentGameId}
 						enablePerks={true}
@@ -385,7 +404,7 @@ function RouteComponent() {
 
 				{/* Right Section (Info Panel) */}
 				<div className="flex-1 bg-card border-l border-border p-4 overflow-y-auto">
-					<LiveInfoPanel gameId={currentGameId} elapsedTime={elapsedTime} />
+					<LiveInfoPanel gameId={currentGameId} elapsedTime={elapsedTime} config={config} />
 				</div>
 			</div>
 		);

--- a/app/routes/games/orbital-flux_.live.tsx
+++ b/app/routes/games/orbital-flux_.live.tsx
@@ -25,10 +25,10 @@ function formatElapsedTime(startTime: number | undefined, currentTime: number): 
 	let elapsed = Math.max(0, currentTime - startTime) / 1000; // work in seconds
 
 	const days = Math.floor(elapsed / (24 * 60 * 60));
-	elapsed %= (24 * 60 * 60);
+	elapsed %= 24 * 60 * 60;
 
 	const hours = Math.floor(elapsed / (60 * 60));
-	elapsed %= (60 * 60);
+	elapsed %= 60 * 60;
 
 	const minutes = Math.floor(elapsed / 60);
 	const seconds = Math.floor(elapsed % 60);

--- a/app/routes/games/orbital-flux_.live.tsx
+++ b/app/routes/games/orbital-flux_.live.tsx
@@ -404,7 +404,7 @@ function RouteComponent() {
 
 				{/* Right Section (Info Panel) */}
 				<div className="flex-1 bg-card border-l border-border p-4 overflow-y-auto">
-					<LiveInfoPanel gameId={currentGameId} elapsedTime={elapsedTime} config={config} />
+					<LiveInfoPanel gameId={currentGameId} elapsedTime={elapsedTime} />
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Refactor(Orbital Flux): Improve live game UI layout and information display

This commit redesigns the Orbital Flux live game interface (`/games/orbital-flux_/live`) to enhance its usability and presentation, especially for widescreen live streaming.

Key changes include:

1.  **Two-Column Layout:**
    *   The UI is now divided into a left section for the game canvas and stats bar,
        and a right section for auxiliary information.
    *   The left (game) section is centered and sized to maintain the game's
        aspect ratio, using only the necessary width.
    *   The right section utilizes the remaining screen width, making better
        use of available space on wider displays.

2.  **New `LiveInfoPanel` Component:**
    *   Introduced `LiveInfoPanel.tsx` to consolidate information in the right panel.
    *   It now displays:
        *   The list of purchased perks (functionality moved from the deprecated
          `LivePerksPanel.tsx`).
        *   The current Game ID.
        *   The Elapsed Time for the game.
    *   The styling of this panel is flexible to adapt to the available width.

3.  **Relocated Elements:**
    *   Game ID and Elapsed Time were moved from the page footer into the new
        `LiveInfoPanel` in the right column.
    *   The perks display is no longer passed via `customRightPanel` to `OrbitalFlux`
        but is directly part of the new right column structure.

4.  **File Cleanup:**
    *   I removed the now-obsolete `LivePerksPanel.tsx` file.

These changes aim to provide a more focused game view in the left section while offering a comprehensive and user-friendly information panel on the right, improving the overall experience for both players and stream viewers.