### PR TITLE
Fix cross-env timeout types

### DIFF
--- a/app/components/games/orbital-flux/hooks/usePerkHost.ts
+++ b/app/components/games/orbital-flux/hooks/usePerkHost.ts
@@ -16,7 +16,7 @@ interface PerkFromBackend {
 export function usePerkHost(gameId: Id<'games'>) {
 	//
 	const [localActivePerks, setLocalActivePerks] = useState<ActiveEffect[]>([]);
-	const [perkTimers, setPerkTimers] = useState<Map<string, NodeJS.Timeout>>(new Map());
+	const [perkTimers, setPerkTimers] = useState<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
 	// backend queries and mutations
 	const backendPerks = useQuery(api.games.public.getActivePerks, { gameId });
@@ -129,7 +129,7 @@ export function usePerkHost(gameId: Id<'games'>) {
 
 		const now = Date.now();
 		const activePerks: ActiveEffect[] = [];
-		const newTimers = new Map<string, NodeJS.Timeout>();
+		const newTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 		backendPerks.forEach((backendPerk) => {
 			const perk = convertBackendPerk(backendPerk);

--- a/app/routes/games/orbital-flux_.live.tsx
+++ b/app/routes/games/orbital-flux_.live.tsx
@@ -130,7 +130,7 @@ function RouteComponent() {
 	const [isLoading, setIsLoading] = useState(false);
 	const [gameStartTime, setGameStartTime] = useState<number | undefined>(undefined);
 	const [nextPerkTime, setNextPerkTime] = useState<number | null>(null);
-	const perkTimerRef = useRef<NodeJS.Timeout | null>(null);
+	const perkTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	/**
 	 * clears the random perk timer and resets next perk time


### PR DESCRIPTION
## Summary
- avoid Node types on the client by using DOM-safe timeout types

## Testing
- `bun run lint` *(fails: Code style issues found in 3 files)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a77e7908333b0fa73b65fcb634f